### PR TITLE
clarify termination arguments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ When a source is greeted and given a sink as payload, the sink MUST be greeted b
 
 **Termination**: `(type: 2, err?: any) => void`
 
-A callbag is *terminated* when the first argument is `2` and the second argument is either undefined (signalling successful termination) or any truthy value (signalling failed termination).
+A callbag is *terminated* when the first argument is `2` and the second argument is either undefined (signalling termination due to success) or any truthy value (signalling termination due to failure).
 
 After a mutual greet between source and sink, the source MAY terminate the sink. Alternatively, the sink MAY terminate the source. If the source terminates the sink, then the sink SHOULD NOT terminate the source, and vice-versa. In other words, termination SHOULD NOT be mutual.
 


### PR DESCRIPTION
updates the docs to clarify some confusion around #7 

I can see how reading this document might lead one to believe that `failed termination` means "a failure to terminate". I __think__ it actually means "a termination due to a failure". Does this clarify it a bit without over-complicating? I know it's a bit pedantic, but I think it helps.