### PR TITLE
Add typings for different callbag lifecycle points

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -10,5 +10,20 @@ export type RESERVED_8 = 8;
 export type RESERVED_9 = 9;
 
 export type Callbag = (type: START | DATA | END, payload?: any) => void;
-export type Factory = (...args: Array<any>) => Callbag;
-export type Operator = (...args: Array<any>) => (source: Callbag) => Callbag;
+
+export type SourceTalkback =
+& ((request: DATA) => void)
+& ((terminate: END) => void);
+
+export type SinkTalkback =
+& ((start: START, sourceTalkback: SourceTalkback) => void)
+& ((deliver: DATA, data: any) => void)
+& ((terminate: END, error?: any) => void);
+
+export type SourceInitiator = (type: START, payload: SinkTalkback) => void;
+
+export type SinkConnector = (source: SourceInitiator) => SourceInitiator | void;
+
+export type SourceFactory = (...args: any[]) => SourceInitiator;
+
+export type Operator = (...args: any[]) => SinkConnector;


### PR DESCRIPTION
This PR adds detailed typings for the different artifacts appearing in different points in the callbag usage lifecycle. Detailed reasoning here: http://blog.krawaller.se/posts/explaining-callbags-via-typescript-definitions

Not at all sure whether...

* the reasoning behind them is correct
* they should live in the spec at all
* they can stand on their own without explanatory comments

I tried my hand at editing the spec text using the same vocabulary as introduced here, hoping to make it more clear, but I didn't really like the result. Yes you need to eventually be able to separate between all these concepts, and having an exact vocabulary helps you do that, but that doesn't mean it's helpful to have them shoved in your face from the get-go.

Also the spec as written is very clean, which has a big value of its own.
