### PR TITLE
split callbag type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -9,6 +9,11 @@ export type RESERVED_7 = 7;
 export type RESERVED_8 = 8;
 export type RESERVED_9 = 9;
 
-export type Callbag = (type: START | DATA | END, payload?: any) => void;
+export type Callbag =
+  & ((start: START, talkback: Callbag) => void)
+  & ((data: DATA, payload?: any) => void)
+  & ((terminate: END, error?: any) => void);
+
 export type Factory = (...args: Array<any>) => Callbag;
+
 export type Operator = (...args: Array<any>) => (source: Callbag) => Callbag;

--- a/types.d.ts
+++ b/types.d.ts
@@ -12,7 +12,7 @@ export type RESERVED_9 = 9;
 export type Callbag =
   & ((start: START, talkback: Callbag) => void)
   & ((data: DATA, payload?: any) => void)
-  & ((terminate: END, error?: any) => void);
+  & ((end: END, error?: any) => void);
 
 export type Factory = (...args: Array<any>) => Callbag;
 


### PR DESCRIPTION
The remnant from #17! Splitting the `Callbag` type to get better intellisense and disallow bad type-payload combinations such as `(0, 'foo')`.