### PR TITLE
Make Callbag a generic type

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "devDependencies": {
     "ts-node": "^4.1.0",
     "typescript": "^2.6.2"
+  },
+  "peerDependencies": {
+    "typescript": ">=2.3.0 <3.0.0"
   }
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -9,11 +9,11 @@ export type RESERVED_7 = 7;
 export type RESERVED_8 = 8;
 export type RESERVED_9 = 9;
 
-export type Callbag =
+export type Callbag<T = any, E = any> =
   & ((start: START, talkback: Callbag) => void)
-  & ((data: DATA, payload?: any) => void)
-  & ((end: END, error?: any) => void);
+  & ((data: DATA, payload?: T) => void)
+  & ((end: END, error?: E) => void);
 
-export type Factory = (...args: Array<any>) => Callbag;
+export type Factory = <T = any, E = any>(...args: Array<any>) => Callbag<T, E>;
 
-export type Operator = (...args: Array<any>) => (source: Callbag) => Callbag;
+export type Operator = <T = any, E = any>(...args: Array<any>) => (source: Callbag) => Callbag<T, E>;


### PR DESCRIPTION
Hey, thanks for your work on callbag. I'm currently writing a library working with the main reactive streams / observable libraries (rxjs, xstream, most) and would also like for it to be available with callbags.

This change is to make `Callbag` a generic type, and it needs TypeScript >= 2.3.0 (for type parameter default).