### PR TITLE
Change input(output) of source(sink)s to "never"

### DIFF
--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -25,4 +25,5 @@ acailly        | Antoine Cailly,
 krawaller      | David Waller, david@krawaller.se
 bloodyKnuckles | Jay Scott ANDERSON
 Andarist       | Mateusz Burzyński, mateuszburzynski@gmail.com
+loreanvictor   | Eugene Ghanizadeh Khoub, ghanizadeh.eugene@gmail.com
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -22,12 +22,12 @@ export type Callbag<I, O> = {
 /**
  * A source only delivers data
  */
-export type Source<T> = Callbag<void, T>;
+export type Source<T> = Callbag<never, T>;
 
 /**
  * A sink only receives data
  */
-export type Sink<T> = Callbag<T, void>;
+export type Sink<T> = Callbag<T, never>;
 
 export type SourceFactory<T> = (...args: Array<any>) => Source<T>;
 


### PR DESCRIPTION
Re [this issue](https://github.com/staltz/callbag-subject/issues/4), specifically [this suggestion](https://github.com/staltz/callbag-subject/issues/4#issuecomment-712091940) and [this follow-up](https://github.com/staltz/callbag-subject/issues/4#issuecomment-712812308). To summarize:

- This change makes `Callbag<X, Y>` assignable to `Source<Y>`
- This change disallows `s(1)` and `s(1, any)` where `s` is a source

