### PR TITLE
More sound typing using tuples instead of overloads

### DIFF
--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -27,4 +27,5 @@ bloodyKnuckles | Jay Scott ANDERSON
 Andarist       | Mateusz Burzyński, mateuszburzynski@gmail.com
 loreanvictor   | Eugene Ghanizadeh Khoub, ghanizadeh.eugene@gmail.com
 devanshj       | Devansh Jethmalani, jethmalani.devansh@gmail.com
+niieani        | Bazyli Brzoska, bazyli.brzoska@gmail.com
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -9,14 +9,24 @@ export type RESERVED_7 = 7;
 export type RESERVED_8 = 8;
 export type RESERVED_9 = 9;
 
+export type CallbagArgs<I, O> =
+  // handshake:
+  | [type: typeof START, talkback: Callbag<O, I>]
+  // data from source:
+  | [type: typeof DATA, data: I]
+  // pull request:
+  | [type: typeof DATA]
+  // error:
+  | [type: typeof END, error: unknown]
+  // end without error:
+  | [type: typeof END, _?: undefined]
+
 /**
  * A Callbag dynamically receives input of type I
  * and dynamically delivers output of type O
  */
 export interface Callbag<I, O> {
-  (t: START, d: Callbag<O, I>): void;
-  (t: DATA, d: I): void;
-  (t: END, d?: any): void;
+  (...args: CallbagArgs<In, Out>): void
 }
 
 /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -11,15 +11,15 @@ export type RESERVED_9 = 9;
 
 export type CallbagArgs<I, O> =
   // handshake:
-  | [type: typeof START, talkback: Callbag<O, I>]
+  | [type: START, talkback: Callbag<O, I>]
   // data from source:
-  | [type: typeof DATA, data: I]
+  | [type: DATA, data: I]
   // pull request:
-  | [type: typeof DATA]
+  | [type: DATA]
   // error:
-  | [type: typeof END, error: unknown]
+  | [type: END, error: unknown]
   // end without error:
-  | [type: typeof END, _?: undefined]
+  | [type: END, _?: undefined]
 
 /**
  * A Callbag dynamically receives input of type I


### PR DESCRIPTION
<!-- Please remember to also add your name to the file CopyrightWaivers.txt. Thanks! -->

This PR uses tuples instead of overloads, to allow TypeScript to correctly narrow the type of the second argument based on the type in the first argument.

Verified that the variance (updated in https://github.com/callbag/callbag/pull/53/commits/4a9b347dfc5b0ab8ad63232ce9d46a31edaebfda) is still working as expected, see [playground](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBDAnmYcDKAVAggJQ3AXjgAYBuAKFElgWVQBEttC4BGCq6eJFOAUQBy9FgCYKlcF1q8AwgEMANgoBGcgOZYoagM4AeAJIA7ADRwA8gFcYAPkLk4cAPSO4ACzmGAJtvcBrYABc9nAAPnAA2jyB6Nh4pjCKvqoAxr4BcPJKqmq6ljCmRtYAuk4uYWgJCjAAXpkq6rlWBYbWwc5whqAwQQ5hkXTpjNimnnIJ6UZFbS5gFkpwUMAAjhbA2t3BfVGDTFhTDu3AUFDQPaER2-xCpkcnUOkWhr6GEADuhvulcMBeZ1sDV3on3+KHSgnoIzGcgA-A8vMAAGYAS06nimEmo8BRMCOCLkyVQdWyBhM5istgA3tM4AAKboxXAYEbpIkNPLNawASnSADcIEjPBQDi46TthnBPBNDNy4HyBUKvqLASNYXAPIgZXLBcEaQA6fVyLTaFmKeoaI0k0x5Lm8-mecgAX3I5HaUXQEAsUAJugwtiIrJynR5R1MvpdLjdaBRvh9foypuJTI6wGDUFanBo2Nx+NQaA9XuAse+IBxXm08ayDSDIbgvrgFKdGaxhhxUDxBPQ0aLXR+3grZp9pmrafrTvInmAyQUhtQCMeyRgSIghjgAFs5P4o09YzSZVuY76KBOpzO4HPDAulyv15v897fbv0nnPffrEfJ9PFmf54vl2uN8AAYGFa1iPv2xL6CB4jJMu6xqqwT5dgA5FgSFxjewD7roKFIecSEAEJobuFAwYYcFyCIiHbjheGEehAFYThoGctBsHwHIADMJqVjkOFDimRz0f4QE0WEBFIfxqbMSRbFqgALNxA6iXA4mSYJLAYSJqFqWmxHOqRcHaAh7ovoWTEaQxd5mahtFESx5AGfA2iUSZBbYTZYl0RZt6me5dmsWRTlceBVYCVApjmUQmkJqFqYRR5Kl0XpjlwNoCkhYGYXxbhnlod5gExZlcUqah0nkEAA).

See an example of how this improves error detection. Current implementation makes all of these example errors go undetected: [Playground Link](https://www.typescriptlang.org/play?jsx=0#code/KYDwDg9gTgLgBDAnmYcDKAVAggJQ3AXjgAYBuAKFElgWVQBEttC4BGCq6eJFOAUQBy9FgCYKAYwgA7AM7xMufETLlJs+I2ZF2q6XP5DRFSuC61eAYQCGAGxsAjKwHMsUJzIA8ASSkAaOADyAK4wAHyE5HBwAPTRcAAWVlIAJjKJANbAAFyRcAA+cADaPNno2Hj+MLbpjuLpWXDWdo5OHsEw-j6hALq5sXBSoDA5UQXFdA2aWP7JVlUNPr1R-WBBdnBQwACOQcByI-lFJZNMWEsxccBQUNAHY8cG9P5XN1ANQVLpUhAA7lLn-WAKTuRwmj38AH0APzvFLAABmAEtBsleiZqPBkTArvCrOJUE0HM5vH5AiFwgBvPpxAAUwzKihmDUJLTaIU6UlCAEoGgA3CCI5IUZa0+lTJlwHw8uD8wXCi5wOkNQRPODJGFwJKIaWyoW5GkAOiNVjcMmZtiJLlNJP87W5fIFyXIAF9yOizFicXjUGgIEEoPiPBhwkMgalGhbWYNeVd-MG4BTXZwaJ6oLj8ehkekgyGQNiUjII81iRh-NGrpTXe6aGp9KArABbMA2YBoLMNNufDwAcmxcmRTm74QI+qNBpN7i5hEpuSiiPhionMkKxG6hAIRAUeCnVKie7gte41Vq6RYS8KrHO+6qNhqePSNPFcG7kmuwHEMBsiDgL2gMm7XKznuKxrDYcA-NA6QyEBUQ3nedSPqcgH7iKP4pOBkHQShCDHveNIqshe5Vvu86LqaK5rhuRBTHAABktGaqaBotlITgwPE65ECIO4wQeejwLMVRnuRl68f0glWHAiKFq+mwfl+cAQAuJTPn2MADt2QHEXupE0ueq6cY8PHYYeP7XNAABqti7MJ7gXlewGXOZUBWTYNnSXxb7yd+3YfF8vxSJp+6ulEVamfWTYtr6-r4h2foBsAPZqRpw6jsappTgQM77v056XlJhZ+d8fyatw8QeZAWL+B86lgYiMDdoWmxIiicD2N+7EeaRchzMADZAsMQG6fpa4AIQbgy24bMAMD+lIbo5XExVSQ1MnQHJn7fsi8IvMAySaoWkmdqe8LQKpezqax3YHFEpkyFmtnLqJQGmXBJ5xTFiW9hdKUsIa6WTtOCa8cN5EGVRcBTFOmyzVAUgxAAVKsdgI9EIMLnpYOURNBHTbD8PRAjYao1pC17qZPw3Kx0UJR9CU9pT0iDsOiqZZWZOoRBUBQZ5G0KT89UcW9943XA92fDSW6ljht4noRqG-lAhY-PEQIIKrYvxRmEkFVJUiye+g37uLD5S-4jPU1rwCAUB-RczzAvsbzhtqnMknHEBJuIdg-jff2V0HXx6jywquKIjYyuC3rBsfq7Qke8bWbe9Mz4W04cdWN2geHjbi3q3sqAmqgEDpFYiD+FqnWsXATgQHscCnVAZmvKLXsqmWwA-Pwzk0lyIdt0I-dJ+3cAfMkCLInthFVkAA)